### PR TITLE
Add Handrail (fail-closed deny/ask hooks) to Safety and Protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Hooks that detect and block prompt injection attacks in tool outputs.
 
 Hooks that prevent Claude Code from making unwanted changes.
 
+- [Handrail](https://github.com/trimkeep/handrail-kit) - Fail-closed deny/ask hooks for Claude Code & other agent CLIs. Triggers on: `PreToolUse`.
 - [wangbooth/Claude-Code-Guardrails](https://github.com/wangbooth/Claude-Code-Guardrails) - Protective hooks that prevent accidental code loss through branch protection, automatic checkpointing, and safe commit squashing. 51 stars. Triggers on: `PreToolUse`, `PostToolUse`.
 - [gstack freeze/guard](https://github.com/garrytan/gstack) - Lock critical files from modification. Uses `PreToolUse` hook definitions in SKILL.md frontmatter (not hooks.json) with real shell scripts (`freeze/bin/check-freeze.sh`). Note: only enforced in Claude Code — generated Codex skill docs are advisory prose only. Found in `freeze/SKILL.md.tmpl` and `guard/SKILL.md.tmpl`. Triggers on: `PreToolUse` (Write/Edit).
 - [Everything Claude Code hook profiles](https://github.com/affaan-m/everything-claude-code) - 26 hook entries across 7 event groups with 27 hook scripts. Three preset safety levels: minimal, standard, strict. Codex-verified counts: 116 skills, 28 agents, 59 commands. Triggers on: `PreToolUse`, `PostToolUse`, and 5 other event types.


### PR DESCRIPTION
Adds Handrail under Safety and Protection, one hook pack per PR as the guidelines ask.

Six PreToolUse deny/ask rules (destructive shell, git force-push/reset, secret paths, prod-environment commands, package publish, remote code piped to a shell) that fail closed on empty stdin, non-JSON input, missing tool_input or a missing jq, and only tighten existing permissions. Used daily on the maintainer's own repositories; tests and fixtures in the repo. MIT.

Disclosure: I maintain this project. Handrail is not affiliated with, endorsed by, or a product of Anthropic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Handrail README entry to document Claude Code support.
  - Removed references to other agent command-line interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->